### PR TITLE
[19.0][FIX] hr_employee_firstname: Use work_contact_id instead of address_home_id

### DIFF
--- a/hr_employee_firstname/models/hr_employee.py
+++ b/hr_employee_firstname/models/hr_employee.py
@@ -9,7 +9,7 @@ from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
-UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "address_home_id"]
+UPDATE_PARTNER_FIELDS = ["firstname", "lastname", "user_id", "work_contact_id"]
 
 
 class HrEmployee(models.Model):
@@ -171,7 +171,7 @@ class HrEmployee(models.Model):
     def _update_partner_firstname(self):
         for employee in self:
             partners = employee.mapped("user_id.partner_id")
-            partners |= employee.mapped("address_home_id")
+            partners |= employee.mapped("work_contact_id")
             partners.write(
                 {"firstname": employee.firstname, "lastname": employee.lastname}
             )


### PR DESCRIPTION
Changes needed until this [PR](https://github.com/OCA/hr/pull/1574) is not merged in OCA.